### PR TITLE
Add a new package named standard-own

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Documenting the explosion of packages in the [`standard`](https://github.com/fer
 - **[jsw](https://www.npmjs.com/package/jsw)** - "the spec doesnt care about semicolons and neither should you"
 - **[obama](https://www.npmjs.com/package/obama)** - Move forward and standardize with Obama
 - **[aStandard](https://npmjs.com/package/a-standard)** - A stricter standard made for babel and es7
+- **[standard-own](https://npmjs.com/package/standard-own)** - standard but with more customization and individual rules.
 
 PRs welcome!
 


### PR DESCRIPTION
Hi, I just wrote a [package (o2team/standard-own)](https://github.com/o2team/standard-own) using `standard-engine`, it's like `standard` but with more customization, which allows people to tweak individual rules.