### PR TITLE
Remove gulp-any-standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Documenting the explosion of packages in the [`standard`](https://github.com/fer
 
 - **[grunt-standard](https://www.npmjs.com/package/grunt-standard)** - Grunt plugin for standard
 - **[gulp-standard](https://www.npmjs.com/package/gulp-standard)** - Gulp plugin for standard
-- **[gulp-any-standard](https://www.npmjs.com/package/gulp-any-standard)** - Gulp plugin that supports standard and its forks
 - **[mocha-standard](https://www.npmjs.com/package/mocha-standard)** - Integrates standard into your mocha tests
 - **[standard-loader](https://www.npmjs.com/package/standard-loader)** - Lint webpack builds with standard
 - **[generator-babel-standard](https://www.npmjs.com/package/generator-babel-standard)** - Yeoman generator for new packages with babel and standard


### PR DESCRIPTION
[gulp-any-standard](https://www.npmjs.com/package/gulp-any-standard) hasn’t been updated for two years and the [associated GitHub repository](https://github.com/dcousens/gulp-any-standard) no longer exists.