### PR TITLE
docs: update prettier-standard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Documenting the explosion of packages in the [`standard`](https://github.com/fer
 ## automatic code formatters
 
 - `standard --fix` - automatic formatting is built-in to `standard`!
-- **[prettier-standard](https://www.npmjs.com/package/prettier-standard)** - format with [prettier](https://github.com/prettier/prettier) configured to standard rules
+- **[prettier-standard](https://www.npmjs.com/package/@ksmithut/prettier-standard)** - format with [prettier](https://github.com/prettier/prettier) configured to standard rules
 - **["unix commands" gist](https://gist.github.com/watson/453fc63cace521fcdadc)** - A list of search and replace unix commands to help make a node repository 'standard' compliant
 
 ## editor plugins


### PR DESCRIPTION
## What is the purpose of this pull request? (put an "X" next to item)

[x] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

## What changes did you make? (Give an overview)

Updated the link to the VS Code extension for automatic code formatter `prettier-standard`.

Many users including me encountering deprecation warning and errors due to outdated packages. It seems the original author is unable to keep up the project and @ksmithut is currently maintaining the project through [his fork](https://github.com/ksmithut/prettier-standard).